### PR TITLE
Change Viewer config for easier copy-paste

### DIFF
--- a/src/Components/Viewer/Config.tsx
+++ b/src/Components/Viewer/Config.tsx
@@ -1,10 +1,31 @@
 import { SimResults } from "./DataType";
+import { KeyboardEvent, ClipboardEvent, MouseEvent} from "react";
 
 export function Config({ data }: { data: SimResults }) {
-  return (
+    function onKeyDown(e: KeyboardEvent) {
+        if (e.metaKey || e.ctrlKey) {
+            return true;
+        }
+        e.preventDefault()
+        return false;
+    }
+    function preventDefault(e: ClipboardEvent) {
+        e.preventDefault();
+        return false;
+    }
+
+    function copyToClipboard(e: MouseEvent) {
+        navigator.clipboard.writeText(data.config_file)
+        // TODO: Need to add a blueprintjs Toaster for ephemeral confirmation box
+    }
+    return (
     <div>
-      <div className="m-2 p-2 rounded-md bg-gray-600">
-        <pre className="whitespace-pre-wrap">{data.config_file}</pre>
+        <button className="m-2 p-2 rounded-md bg-gray-600" onClick={ copyToClipboard }>Copy Config to Clipboard
+        </button>
+        <div className="m-2 p-2 rounded-md bg-gray-600" contentEditable="true" onKeyDown={ onKeyDown } onCut={ preventDefault }>
+          <pre className="whitespace-pre-wrap">
+              {data.config_file}
+          </pre>
       </div>
     </div>
   );


### PR DESCRIPTION
Looks like this - let's people copy within config box and also adds a button to copy config. I was going to add a Toaster so there's a nice confirmation box, but it would take me forever so I just left it aside for now...

![image](https://user-images.githubusercontent.com/84653157/154693829-3082d697-3f50-465b-ad75-4cfa8ba45e1f.png)
